### PR TITLE
Remove lane cluster-specific assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ HALPER is designed for constructing contiguous orthologs from the outputs of hal
 
 ## Example Run of HALPER
 Running these examples requires the files in the examples directory and 10plusway-master.hal, a Cactus alignment with 12 mammals that can be obtained from the authors of the paper describing Cactus (see "Relevant Publications" below).  One can compare the outputs of each step to the files with the corresponding names in the examples directory.  To run only HALPER (not halLiftover), go directly to #4.
+
+To run steps 1-4 with a single command, please use `halper_map_peak_orthologs.sh`.
+
 1.  Run halLiftover on the file from the query species (example is in narrowPeak format, so columns not in standard bed format are first removed) to obtain the regions' orthologs in the target species:
 ```
 	[directory with hal]/hal/bin/halLiftover --bedType 4 [directory with Cactus alignment]/10plusway-master.hal Human [directory with halLiftover-postprocessing]/halLiftover-postprocessing/examples/hg38Peaks.bed Mouse hg38Peaks_halLiftovermm10.bed

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -3,12 +3,8 @@
 # Adapted from a script by BaDoi Phan:
 # /projects/pfenninggroup/machineLearningForComputationalBiology/snATAC_cross_species_caudate/code/raw_code/hal_scripts/halper_map_peak_orthologs.sh
 
-#SBATCH --partition=pfen1
-# -w=compute-1-11 because the cactus alignment is on this node
-#SBATCH -w=compute-1-11
 #SBATCH --job-name=halliftover
 #SBATCH --ntasks-per-core=1
-#SBATCH --mem=10G
 #SBATCH --error=logs/halliftover_%A.out.txt
 #SBATCH --output=logs/halliftover_%A.out.txt
 
@@ -32,6 +28,8 @@ function usage()
     echo ""
     echo "sbatch halper_map_peak_orthologs.sh -b myPeaks.narrowPeak -o /dir/to/output/ -s sourceSpecies -t targetSpecies "
     echo ""
+    echo "On the Lane cluster, please use the following sbatch flags to use a node that already has the cactus alignment:"
+    echo "    sbatch -p pfen1 -w compute-1-11 --mem 10000 halper_map_peak_orthologs.sh [other args]"
     echo ""
     echo "Required parameters:"   
     echo "--input-bed-file  -b FILENAME     bed or narrowPeak file, can be gzipped, {.bed/.bed.gz/.narrowpeak/.narrowpeak.gz}"

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file and the readme
+!.gitignore
+!README.md

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,1 @@
+This directory is intentionally empty, as a place for log files.


### PR DESCRIPTION
This PR updates halper_map_peak_orthologs.sh so that it does not assume sbatch flags that are specific to the lane cluster. 