### PR TITLE
Preserve signal

### DIFF
--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -195,7 +195,8 @@ function num_null_values(){
     # $2: column number (integer)
     # echo the number of "-1" values in this column of this file
 
-    cut "-f$2-$2" $1 | grep "\-1" | wc -l
+    res=$(cut "-f$2-$2" $1 | grep "\-1" | wc -l)
+    echo $res
 }
 
 function num_columns(){

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -186,6 +186,20 @@ function run_halLiftover()
     fi
 }
 
+function num_null_values(){
+    # $1: path to file
+    # $2: column number (integer)
+    # echo the number of "-1" values in this column of this file
+
+    cut "-f$2-$2" $1 | grep "\-1" | wc -l
+}
+
+function num_columns(){
+    # $1: path to file
+    # echo number of columns
+    awk '{print NF; exit}' $1
+}
+
 function format_bed()
 {
     ##########################################
@@ -199,7 +213,7 @@ function format_bed()
     elif [[ $(awk '++A[$4] > 1 { print "true"; exit 1 }' $INPUTBED) ]]; then
         echo "Non-unique bed peak names detected. Giving unique names now."
         echo "Bed file doesn't have name column. Adding"
-        if [[ $(awk '{print NF; exit}' ${INPUTBED}) == 10 ]]; 
+        if [[ ($(num_columns $INPUTBED) == 10) && ($(num_null_values $INPUTBED 10) == 0) ]]; 
         # use summit if there's a 10th column (assume narrowpeak file)
             then echo "Appending CHR:START-END:SUMMIT to NAME column."
             awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3 ":" $10, $5, $6, $7, $8, $9, $10}' $INPUTBED > $UNIQUEBED

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -259,7 +259,6 @@ function get_summits()
         echo "No summits found, taking the mean between start and end as the summits."
         awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, int(($2+$3)/2), int(($2+$3)/2)+1, $4, $5, $6}' $UNIQUEBED > $SUMMITFILE
     fi
-    cp $SUMMITFILE ${OUTDIR}/summitfile.bed
 }
 
 function prepare_dirs()

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -202,11 +202,10 @@ function format_bed()
         if [[ $(awk '{print NF; exit}' ${INPUTBED}) == 10 ]]; 
         # use summit if there's a 10th column (assume narrowpeak file)
             then echo "Appending CHR:START-END:SUMMIT to NAME column."
-            # TODO keep columns 8, 9, 10 here, and debug halper
-            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3 ":" $10, $5, $6, $7}' $INPUTBED > $UNIQUEBED
+            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3 ":" $10, $5, $6, $7, $8, $9, $10}' $INPUTBED > $UNIQUEBED
         else # if there isn't a narrowpeak summit column
             echo "Appending CHR:START-END to NAME column."
-            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6, $7}' $INPUTBED > $UNIQUEBED
+            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6, $7, $8, $9, $10}' $INPUTBED > $UNIQUEBED
         fi
     else 
         echo "Bed peak names are unique; moving onwards."

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -133,6 +133,10 @@ while [[ $1 != "" ]]; do
                                 MAX_FRAC=$1
                                 echo "-max_frac is $MAX_FRAC."
                                 ;;                                
+        -preserve )             shift
+                                PRESERVE=$1
+                                echo "-preserve is $PRESERVE."
+                                ;;
         -h | --help )           usage
                                 exit 1
                                 ;;
@@ -325,6 +329,12 @@ function run_halper()
     if ! [[ -z ${KEEPCHRPREFIX+x} ]]; then
         args="${args} -keepChrPrefix $KEEPCHRPREFIX"
     fi
+    if ! [[ -z ${PRESERVE+x} ]]; then
+        # change PRESERVE from comma-delimited to space-delimited for args
+        PRESERVE=$(echo $PRESERVE | tr "," " ")
+        args="${args} -preserve $PRESERVE"
+    fi
+    echo "args: $args"
     python -m orthologFind $args
     echo "Mapped $(line_count $OUTFILE) peaks out of $(line_count $INPUTBED) total peaks."
 

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -202,10 +202,11 @@ function format_bed()
         if [[ $(awk '{print NF; exit}' ${INPUTBED}) == 10 ]]; 
         # use summit if there's a 10th column (assume narrowpeak file)
             then echo "Appending CHR:START-END:SUMMIT to NAME column."
-            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3 ":" $10, $5, $6}' $INPUTBED > $UNIQUEBED
+            # TODO keep columns 8, 9, 10 here, and debug halper
+            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3 ":" $10, $5, $6, $7}' $INPUTBED > $UNIQUEBED
         else # if there isn't a narrowpeak summit column
             echo "Appending CHR:START-END to NAME column."
-            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6}' $INPUTBED > $UNIQUEBED
+            awk 'BEGIN {FS="\t"; OFS="\t"} {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6, $7}' $INPUTBED > $UNIQUEBED
         fi
     else 
         echo "Bed peak names are unique; moving onwards."
@@ -215,6 +216,7 @@ function format_bed()
     #################################################################
     # make sure the scores column is numeric, strand column is +|-|.
     echo "Formatting bed score and strand columns."
+    # NOTE this line converts float values e.g. 5.23 to 0
     awk 'BEGIN {FS="\t"; OFS="\t"} {! $5 ~ /^[[:digit:]]+$/} {$5=0} {print;}' $UNIQUEBED \
         > ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed
     awk 'BEGIN {FS="\t"; OFS="\t"} {! $6 ~ /\+|\-|\./} {$6="."} {print;}' \

--- a/halper_map_peak_orthologs.sh
+++ b/halper_map_peak_orthologs.sh
@@ -234,11 +234,15 @@ function format_bed()
     #################################################################
     # make sure the scores column is numeric, strand column is +|-|.
     echo "Formatting bed score and strand columns."
-    # NOTE this line converts float values e.g. 5.23 to 0
-    awk 'BEGIN {FS="\t"; OFS="\t"} {! $5 ~ /^[[:digit:]]+$/} {$5=0} {print;}' $UNIQUEBED \
-        > ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed
-    awk 'BEGIN {FS="\t"; OFS="\t"} {! $6 ~ /\+|\-|\./} {$6="."} {print;}' \
-        ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed > ${TMP_HAL_DIR}/${NAME}.unique3.${SOURCE}.${TMP_LABEL}.bed
+
+    # Ensure that score column is numeric
+    # Adapted from https://stackoverflow.com/a/33706695
+    # Regex: 1 or more digits, 0 or 1 period, 0 or more digits
+    # If score is not numeric, then set it to 0, otherwise keep it
+    awk 'BEGIN {FS="\t"; OFS="\t"} { if($5 !~ /^[0-9]+\.{0,1}[0-9]*$/){$5 = 0} print;}' $UNIQUEBED > ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed
+
+    # Ensure that strand column is "+", "-", or "."
+    awk 'BEGIN {FS="\t"; OFS="\t"} { if($6 !~ /\+|\-|\./){$6 = "."} print;}' ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed > ${TMP_HAL_DIR}/${NAME}.unique3.${SOURCE}.${TMP_LABEL}.bed
     mv ${TMP_HAL_DIR}/${NAME}.unique3.${SOURCE}.${TMP_LABEL}.bed $UNIQUEBED; rm ${TMP_HAL_DIR}/${NAME}.unique2.${SOURCE}.${TMP_LABEL}.bed
 
     ######################################
@@ -334,7 +338,6 @@ function run_halper()
         PRESERVE=$(echo $PRESERVE | tr "," " ")
         args="${args} -preserve $PRESERVE"
     fi
-    echo "args: $args"
     python -m orthologFind $args
     echo "Mapped $(line_count $OUTFILE) peaks out of $(line_count $INPUTBED) total peaks."
 

--- a/orthologFind.py
+++ b/orthologFind.py
@@ -310,6 +310,7 @@ def ortholog_find(file_H,max_len,alen,min_len,blen,proct_dist,mult_keepone=False
 		peak_len=peak_e-peak_s
 		peak_name=strList[3]
 
+		score_value = "-1" if ((len(strList) < 5) or ('score' not in preserve)) else strList[4]
 		signal_value = "-1" if ((len(strList) < 7) or ('signal' not in preserve)) else strList[6]
 		narrowPeak_pValue = "-1" if ((len(strList) < 8) or ('pvalue' not in preserve)) else strList[7]
 		narrowPeak_qValue = "-1" if ((len(strList) < 9) or ('qvalue' not in preserve)) else strList[8]
@@ -346,7 +347,7 @@ def ortholog_find(file_H,max_len,alen,min_len,blen,proct_dist,mult_keepone=False
 			newLineList.append(str(q_extent[-1]))
 		else:
 			# Format the output line in narrowPeak format
-			newLineList = [summit_seg[2],str(ortho_s),str(ortho_e),peak_name,"-1",".",signal_value,narrowPeak_pValue,narrowPeak_qValue,str(q_extent[-2])]
+			newLineList = [summit_seg[2],str(ortho_s),str(ortho_e),peak_name,score_value,".",signal_value,narrowPeak_pValue,narrowPeak_qValue,str(q_extent[-2])]
 		mapped_chr_name = newLineList[0]
 		newLine = fromStringListToStr(newLineList)
 		if(validOrtholog(q_extent,this_max_len,this_min_len,proct_dist,peak_name,mapped_chr_name,keep_chr_prefix)):

--- a/orthologFind.py
+++ b/orthologFind.py
@@ -279,7 +279,11 @@ def make_hist_peaks(oFile,outname,bin_max):
 finding valid orthologs and then plot the histogram
 '''
 def ortholog_find(file_H,max_len,alen,min_len,blen,proct_dist,mult_keepone=False,
-				  narrowPeak=False, draw_hist=True, keep_chr_prefix=None):
+				  narrowPeak=False, draw_hist=True, keep_chr_prefix=None, preserve=False):
+	if preserve is None:
+		preserve = []
+	preserve = [itm.lower() for itm in preserve]
+
 	qFileH = open(file_H[0],"r")
 	tFileH = open(file_H[1],"r")
 	sFileH = open(file_H[2],"r")
@@ -305,9 +309,11 @@ def ortholog_find(file_H,max_len,alen,min_len,blen,proct_dist,mult_keepone=False
 		peak_e=int(strList[2])
 		peak_len=peak_e-peak_s
 		peak_name=strList[3]
-		signal_value = "-1" if len(strList) < 7 else strList[6]
-		narrowPeak_pValue = "-1" if len(strList) < 8 else strList[7]
-		narrowPeak_qValue = "-1" if len(strList) < 9 else strList[8]
+
+		signal_value = "-1" if ((len(strList) < 7) or ('signal' not in preserve)) else strList[6]
+		narrowPeak_pValue = "-1" if ((len(strList) < 8) or ('pvalue' not in preserve)) else strList[7]
+		narrowPeak_qValue = "-1" if ((len(strList) < 9) or ('qvalue' not in preserve)) else strList[8]
+
 		#if given fraction, calculate max_len 
 		if(not alen):
 			this_max_len = max_len*(peak_e-peak_s+1)
@@ -398,6 +404,9 @@ def main(argv):
 	parser.add_argument('-keepChrPrefix', required=False,
 		help='If passed, then only keep mapped peaks where the new chromosome name starts with this prefix.')
 
+	parser.add_argument('-preserve', required=False, nargs='+',
+		help='Column(s) from the input narrowPeak file to transfer to the output file. Options are "signal", "pValue", "qValue".')
+
 	args = parser.parse_args()
 
 	if(args.max_len is None and args.max_frac is None):
@@ -435,7 +444,8 @@ def main(argv):
 		exit(1)
 	ortholog_find(file_H,max_len,alen,min_len,blen,int(args.protect_dist),
 				  mult_keepone=args.mult_keepone,narrowPeak=args.narrowPeak,
-				  draw_hist=args.noHist,keep_chr_prefix=args.keepChrPrefix);
+				  draw_hist=args.noHist,keep_chr_prefix=args.keepChrPrefix,
+				  preserve=args.preserve);
 		
 
 	

--- a/orthologFind.py
+++ b/orthologFind.py
@@ -324,7 +324,6 @@ def ortholog_find(file_H,max_len,alen,min_len,blen,proct_dist,mult_keepone=False
 			continue
 		#
 		q_extent=extend_summit(q_peak_list,summit_seg)
-		# TODO here is where the error with columns 8-10 is happening
 		if(q_extent == ()):
 			continue
 		# summit_ortho_s,summit_q_pos,summit_ortho_e,sum_len,l_len,r_len


### PR DESCRIPTION
This PR updates `orthologFind.py` and `halper_map_peak_orthologs.sh` such that columns 5, 7, 8, and 9 (score, signal, pValue, and qValue) of a narrowPeak file can be preserved when orthologs are mapped, requested by @badoi .

By default, these values are not preserved, and the resulting orthologs have null values `"-1"`. The user can choose which columns to preserve using the `-preserve` flag, which can take multiple field names separated by commas, e.g. `-preserve score,signal,pValue,qValue`.

If there are null values in the input signal, pValue, or qValue columns, they are still preserved in the output.
If there are values in the input score column that are not a positive number (integer or decimal), they are converted to 0.

These changes have been tested on the Lane cluster and Mac OS Monterey 12.6.
@imk1 this PR is ready to merge.